### PR TITLE
Enable reading codeowners file from project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v0.0.2
+
+- print out meaningful error when running commands in a project without codeowners file
+- fix problem where codeowners file was not detected when it was placed in the root
+
+## v0.0.1
+
+- initial release

--- a/lua/gh-co/fs.lua
+++ b/lua/gh-co/fs.lua
@@ -82,21 +82,34 @@ FS.getCodeownersFilePath = function()
     "Directory " .. codeownerDirName .. " does not seem to exist."
   )
 
-  local codeownerFileName = nil
+  local codeownerFileNameWithinDefaultFolder = nil
   for name, kind in codeownerDirContents do
     if hasCodeownersFile(name, kind) then
-      codeownerFileName = name
+      codeownerFileNameWithinDefaultFolder = name
       break
     end
   end
 
-  if codeownerFileName == nil then return nil end
+  local codeownerFilePath = nil
 
-  local codeownerFilePath = codeownerDirName .. "/" .. codeownerFileName
+  -- handles case when project is storing CODEOWNERS file in root directory
+  if codeownerFileNameWithinDefaultFolder == nil then
+    for name, kind in vim.fs.dir(rootDirName) do
+      if hasCodeownersFile(name, kind) then
+        codeownerFilePath = rootDirName .. "/" .. name
+        FS.cachedCodeownersFilePath = codeownerFilePath
+        break
+      end
+    end
 
-  FS.cachedCodeownersFilePath = codeownerFilePath
+    return codeownerFilePath
+  else
+    codeownerFilePath = codeownerDirName .. "/" .. codeownerFileNameWithinDefaultFolder
 
-  return codeownerFilePath
+    FS.cachedCodeownersFilePath = codeownerFilePath
+
+    return codeownerFilePath
+  end
 end
 
 FS.openCodeownersFile = function()

--- a/lua/gh-co/init.lua
+++ b/lua/gh-co/init.lua
@@ -47,7 +47,7 @@ function checkCodeownersFileExists()
 end
 
 M.healthcheck = function()
-  print('gh-co.nvim is OK!')
+  print('gh-co.nvim plugin loaded OK. Codeowners file path:', FS.cachedCodeownersFilePath or 'not found')
 end
 
 M.showCodeownersFile = function()

--- a/lua/gh-co/init.lua
+++ b/lua/gh-co/init.lua
@@ -42,6 +42,10 @@ function writeBufferOwnerContents(buffer, owners)
   vim.api.nvim_set_current_buf(buffer)
 end
 
+function checkCodeownersFileExists()
+  assert(FS.cachedCodeownersFilePath, "Problem reading Codeowners file path. Try running :GhCoHealthcheck")
+end
+
 M.healthcheck = function()
   print('gh-co.nvim is OK!')
 end
@@ -59,6 +63,7 @@ M.status = function()
 end
 
 M.who = function()
+  checkCodeownersFileExists()
   local filePath = FS.getFilePath()
   local owners = CO.matchFilesToCodeowner({ filePath })
 
@@ -71,6 +76,7 @@ M.who = function()
 end
 
 M.whos = function()
+  checkCodeownersFileExists()
   local filePaths = FS.getFilePaths()
   local owners = CO.matchFilesToCodeowner(filePaths)
 
@@ -88,6 +94,7 @@ M.whos = function()
 end
 
 M.gitWho = function(sha)
+  checkCodeownersFileExists()
   local filePaths = G.getAffectedFiles(sha)
   local owners = CO.matchFilesToCodeowner(filePaths)
 


### PR DESCRIPTION
Fixes a situation when user places codeowners file to project root which is also an allowed location. Adding changelog and minor improvements.
This PR also creates a release.