### PR TITLE
fix pattern matching

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,26 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v10
+      with:
+        luaVersion: "5.4"
+    
+    - name: Setup LuaRocks
+      uses: leafo/gh-actions-luarocks@v4
+    
+    - name: Install dependencies
+      run: luarocks install --deps-only gh-co.nvim-0.0.4-1.rockspec
+    
+    - name: Run linter
+      run: PATH="./lua_modules/bin:$PATH" luacheck lua

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
+  checks:
     runs-on: ubuntu-latest
     
     steps:
@@ -22,5 +22,8 @@ jobs:
     - name: Install dependencies
       run: luarocks install --deps-only gh-co.nvim-0.0.4-1.rockspec
     
-    - name: Run linter
+    - name: Lint
       run: PATH="./lua_modules/bin:$PATH" luacheck lua
+
+    - name: Test
+      run: luarocks test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
       uses: leafo/gh-actions-luarocks@v4
     
     - name: Install dependencies
-      run: luarocks install --deps-only gh-co.nvim-0.0.4-1.rockspec
+      run: luarocks install --deps-only gh-co.nvim-0.0.5-1.rockspec
     
     - name: Lint
       run: PATH="./lua_modules/bin:$PATH" luacheck lua

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/luarocks
+/lua
+/lua_modules
+/.luarocks

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /luarocks
-/lua
 /lua_modules
 /.luarocks

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,5 +3,7 @@ globals = {"vim"}
 
 ignore = {
   -- unused loop variable
-  "213"
+  "213",
+  -- ignore unused test functions
+  "[Tt]est[%w_]+",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+std = "luajit"
+globals = {"vim"}
+
+ignore = {
+  -- unused loop variable
+  "213"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## v0.0.5
+
+- add luarocks & unit tests
+- fix incompatibility with CODEOWNERS spec, the plugin can now work with various patterns, can handle paths marked with no owner(s) or wildcard patterns
+- fix highlighting, add treesitter support
+
 ## v0.0.4
+
 - syntax highlighting for `CODEOWNERS` file
 
 ## v0.0.3

--- a/gh-co.nvim-0.0.4-1.rockspec
+++ b/gh-co.nvim-0.0.4-1.rockspec
@@ -1,0 +1,25 @@
+rockspec_format = "3.0"
+package = "gh-co.nvim"
+version = "0.0.4-1"
+source = {
+   url = "git+ssh://git@github.com/comatory/gh-co.nvim.git"
+}
+description = {
+   summary = "Github CODEOWNERS Neovim plugin",
+   detailed = "Displays the code owners for current buffer, all opened buffers or lists owners by providing git SHAs",
+   homepage = "https://github.com/comatory/gh-co.nvim",
+   license = "CC0 1.0 Universal"
+}
+dependencies = {
+   "lua ~> 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["gh-co.co"] = "lua/gh-co/co.lua",
+      ["gh-co.fs"] = "lua/gh-co/fs.lua",
+      ["gh-co.git"] = "lua/gh-co/git.lua",
+      ["gh-co.init"] = "lua/gh-co/init.lua",
+      ["gh-co.syntax"] = "lua/gh-co/syntax.lua"
+   }
+}

--- a/gh-co.nvim-0.0.4-1.rockspec
+++ b/gh-co.nvim-0.0.4-1.rockspec
@@ -12,7 +12,10 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "luacheck"
+   "luacheck",
+}
+test_dependencies = {
+   "luaunit >= 3.4"
 }
 build = {
    type = "builtin",
@@ -23,4 +26,8 @@ build = {
       ["gh-co.init"] = "lua/gh-co/init.lua",
       ["gh-co.syntax"] = "lua/gh-co/syntax.lua"
    }
+}
+test = {
+  type = "command",
+  command = "lua -l lua/setup lua/gh-co/co.test.lua -o TAP"
 }

--- a/gh-co.nvim-0.0.4-1.rockspec
+++ b/gh-co.nvim-0.0.4-1.rockspec
@@ -11,7 +11,7 @@ description = {
    license = "CC0 1.0 Universal"
 }
 dependencies = {
-   "lua ~> 5.1"
+   "lua >= 5.1"
 }
 build = {
    type = "builtin",

--- a/gh-co.nvim-0.0.4-1.rockspec
+++ b/gh-co.nvim-0.0.4-1.rockspec
@@ -11,7 +11,8 @@ description = {
    license = "CC0 1.0 Universal"
 }
 dependencies = {
-   "lua >= 5.1"
+   "lua >= 5.1",
+   "luacheck"
 }
 build = {
    type = "builtin",

--- a/gh-co.nvim-0.0.5-1.rockspec
+++ b/gh-co.nvim-0.0.5-1.rockspec
@@ -1,0 +1,33 @@
+rockspec_format = "3.0"
+package = "gh-co.nvim"
+version = "0.0.5-1"
+source = {
+   url = "git+ssh://git@github.com/comatory/gh-co.nvim.git"
+}
+description = {
+   summary = "Github CODEOWNERS Neovim plugin",
+   detailed = "Displays the code owners for current buffer, all opened buffers or lists owners by providing git SHAs",
+   homepage = "https://github.com/comatory/gh-co.nvim",
+   license = "CC0 1.0 Universal"
+}
+dependencies = {
+   "lua >= 5.1",
+   "luacheck",
+}
+test_dependencies = {
+   "luaunit >= 3.4"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["gh-co.co"] = "lua/gh-co/co.lua",
+      ["gh-co.fs"] = "lua/gh-co/fs.lua",
+      ["gh-co.git"] = "lua/gh-co/git.lua",
+      ["gh-co.init"] = "lua/gh-co/init.lua",
+      ["gh-co.syntax"] = "lua/gh-co/syntax.lua"
+   }
+}
+test = {
+  type = "command",
+  command = "lua -l lua/setup lua/gh-co/co.test.lua -o TAP"
+}

--- a/lua/gh-co/co.lua
+++ b/lua/gh-co/co.lua
@@ -116,8 +116,18 @@ CO.matchFilesToCodeowner = function(filePaths)
 
   sortMatches(matches)
 
-  local codeownersList = mapCodeowners(matches)
-
+  -- Only use the most specific pattern(s) - those with the longest pathPattern
+  local maxLength = #matches[1].pathPattern
+  local mostSpecificMatches = {}
+  for _, match in ipairs(matches) do
+    if #match.pathPattern == maxLength then
+      table.insert(mostSpecificMatches, match)
+    else
+      break -- Since sorted by length, we can break early
+    end
+  end
+  
+  local codeownersList = mapCodeowners(mostSpecificMatches)
   return codeownersList
 end
 

--- a/lua/gh-co/co.lua
+++ b/lua/gh-co/co.lua
@@ -9,22 +9,22 @@ end
 local function buildEscapedPattern(rawPattern)
   -- Escape Lua pattern special characters except *
   local escaped = string.gsub(rawPattern, "([%-%+%?%(%)])", "%%%1")
-  
+
   -- Handle ** first (before single *) - use placeholder to avoid conflicts
   escaped = string.gsub(escaped, "%*%*", "__DOUBLESTAR__")
-  
+
   -- Convert remaining * to match any character except /
   escaped = string.gsub(escaped, "%*", "[^/]*")
-  
+
   -- Replace placeholder with pattern that matches any path including /
   escaped = string.gsub(escaped, "__DOUBLESTAR__", ".*")
-  
+
   -- Special handling for **/name patterns - they should match directories
   if string.match(rawPattern, "%*%*/[^/]+$") then
     -- **/logs should match files within logs directories
     escaped = escaped .. "/"
   end
-  
+
   -- Handle trailing slash - directory patterns should match everything within
   if string.match(escaped, "/$") then
     -- Remove trailing slash and match anything that starts with this path
@@ -34,7 +34,7 @@ local function buildEscapedPattern(rawPattern)
     -- Anchor non-directory patterns to match exactly
     escaped = escaped .. "$"
   end
-  
+
   return escaped
 end
 
@@ -126,7 +126,7 @@ CO.matchFilesToCodeowner = function(filePaths)
       break -- Since sorted by length, we can break early
     end
   end
-  
+
   local codeownersList = mapCodeowners(mostSpecificMatches)
   return codeownersList
 end

--- a/lua/gh-co/co.lua
+++ b/lua/gh-co/co.lua
@@ -11,10 +11,17 @@ local function buildEscapedPattern(rawPattern)
   local escaped = string.gsub(rawPattern, "([%-%+%?%(%)])", "%%%1")
   -- Convert * to match any character except /
   escaped = string.gsub(escaped, "%*", "[^/]*")
-  -- Anchor pattern to match from start if it doesn't begin with /
-  if not string.match(escaped, "^/") then
+  
+  -- Handle trailing slash - directory patterns should match everything within
+  if string.match(escaped, "/$") then
+    -- Remove trailing slash and match anything that starts with this path
+    escaped = string.gsub(escaped, "/$", "/")
+    -- Don't anchor with $ - allow matching subdirectories
+  elseif not string.match(escaped, "^/") then
+    -- Anchor non-directory patterns to match exactly
     escaped = escaped .. "$"
   end
+  
   return escaped
 end
 

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -76,4 +76,19 @@ function TestCO:testMatchFilesToCodeownerEmpty() -- luacheck: ignore 212
   lu.assertEquals(result, {})
 end
 
+function TestCO:testGlobalPattern() -- luacheck: ignore 212
+  -- Test * pattern matches all files and assigns global owners
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"* @global-owner1 @global-owner2"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"README.md", "src/main.js"})
+  lu.assertEquals(result, {"@global-owner1", "@global-owner2"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -86,7 +86,7 @@ function TestCO:testGlobalPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"README.md", "src/main.js"})
   lu.assertEquals(result, {"@global-owner1", "@global-owner2"})
 end
@@ -101,7 +101,7 @@ function TestCO:testJavaScriptPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"app.js", "utils.js"})
   lu.assertEquals(result, {"@js-owner"})
 end
@@ -116,7 +116,7 @@ function TestCO:testGoPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"main.go", "server.go"})
   lu.assertEquals(result, {"docs@example.com"})
 end
@@ -131,7 +131,7 @@ function TestCO:testTxtPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"README.txt", "notes.txt"})
   lu.assertEquals(result, {"@octo-org/octocats"})
 end
@@ -146,7 +146,7 @@ function TestCO:testBuildLogsDirectoryPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"/build/logs/app.log", "/build/logs/error.log"})
   lu.assertEquals(result, {"@doctocat"})
 end
@@ -161,7 +161,7 @@ function TestCO:testDocsWildcardPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"docs/README.md", "docs/guide.txt"})
   lu.assertEquals(result, {"docs@example.com"})
 end
@@ -176,7 +176,7 @@ function TestCO:testDocsWildcardDoesNotMatchSubdirectories() -- luacheck: ignore
       return lines[i]
     end
   end
-  
+
   -- Debug: Test what the pattern should do
   -- docs/* should match "docs/readme.md" but NOT "docs/sub/readme.md"
   local result = CO.matchFilesToCodeowner({"docs/sub/readme.md"})
@@ -197,15 +197,15 @@ function TestCO:testCombinedWithGlobalPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   -- JS files should match specific owner (*.js overrides *)
   local result1 = CO.matchFilesToCodeowner({"app.js"})
   lu.assertEquals(result1, {"@js-owner"})
-  
+
   -- Docs files should match docs owner (docs/* overrides *)
   local result2 = CO.matchFilesToCodeowner({"docs/README.md"})
   lu.assertEquals(result2, {"docs@example.com"})
-  
+
   -- Files with no specific pattern should fall back to global owner
   local result3 = CO.matchFilesToCodeowner({"README.py"})
   lu.assertEquals(result3, {"@global-owner"})
@@ -221,7 +221,7 @@ function TestCO:testAppsDirectoryPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"apps/web/index.js", "apps/mobile/main.kt"})
   lu.assertEquals(result, {"@octocat"})
 end
@@ -236,7 +236,7 @@ function TestCO:testRootDocsDirectoryPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"/docs/api.md", "/docs/guides/setup.md"})
   lu.assertEquals(result, {"@doctocat"})
 end
@@ -251,7 +251,7 @@ function TestCO:testRootScriptsDirectoryPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"/scripts/deploy.sh", "/scripts/test.py"})
   lu.assertEquals(result, {"@doctocat", "@octocat"})
 end
@@ -266,7 +266,7 @@ function TestCO:testDoubleStarLogsPattern() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   local result = CO.matchFilesToCodeowner({"build/logs/error.log", "app/server/logs/access.log", "logs/debug.log"})
   lu.assertEquals(result, {"@octocat"})
 end
@@ -284,7 +284,7 @@ function TestCO:testAppsWithEmptyGithubSubdirectory() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   -- Files in /apps/github should have no owners (empty pattern overrides /apps/)
   local githubResult = CO.matchFilesToCodeowner({"/apps/github/readme.md"})
   lu.assertEquals(githubResult, {})
@@ -303,7 +303,7 @@ function TestCO:testAppsWithGithubSubdirectoryOwner() -- luacheck: ignore 212
       return lines[i]
     end
   end
-  
+
   -- Files in /apps/github should have @doctocat (overrides /apps/)
   local githubResult = CO.matchFilesToCodeowner({"/apps/github/readme.md"})
   lu.assertEquals(githubResult, {"@doctocat"})

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -1,0 +1,7 @@
+local lu = require("luaunit")
+
+local function TestCodeowners()
+  lu.assertEquals(1, 1)
+end
+
+os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -91,4 +91,49 @@ function TestCO:testGlobalPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@global-owner1", "@global-owner2"})
 end
 
+function TestCO:testJavaScriptPattern() -- luacheck: ignore 212
+  -- Test *.js pattern matches JavaScript files
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"*.js @js-owner"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"app.js", "utils.js"})
+  lu.assertEquals(result, {"@js-owner"})
+end
+
+function TestCO:testGoPattern() -- luacheck: ignore 212
+  -- Test *.go pattern matches Go files
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"*.go docs@example.com"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"main.go", "server.go"})
+  lu.assertEquals(result, {"docs@example.com"})
+end
+
+function TestCO:testTxtPattern() -- luacheck: ignore 212
+  -- Test *.txt pattern matches text files with team owner
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"*.txt @octo-org/octocats"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"README.txt", "notes.txt"})
+  lu.assertEquals(result, {"@octo-org/octocats"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -290,4 +290,23 @@ function TestCO:testAppsWithEmptyGithubSubdirectory() -- luacheck: ignore 212
   lu.assertEquals(githubResult, {})
 end
 
+function TestCO:testAppsWithGithubSubdirectoryOwner() -- luacheck: ignore 212
+  -- Test /apps/ with /apps/github having different owner
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {
+      "/apps/ @octocat",
+      "/apps/github @doctocat"
+    }
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  -- Files in /apps/github should have @doctocat (overrides /apps/)
+  local githubResult = CO.matchFilesToCodeowner({"/apps/github/readme.md"})
+  lu.assertEquals(githubResult, {"@doctocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -226,4 +226,19 @@ function TestCO:testAppsDirectoryPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@octocat"})
 end
 
+function TestCO:testRootDocsDirectoryPattern() -- luacheck: ignore 212
+  -- Test /docs/ pattern matches files in root docs directory
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"/docs/ @doctocat"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"/docs/api.md", "/docs/guides/setup.md"})
+  lu.assertEquals(result, {"@doctocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -271,4 +271,23 @@ function TestCO:testDoubleStarLogsPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@octocat"})
 end
 
+function TestCO:testAppsWithEmptyGithubSubdirectory() -- luacheck: ignore 212
+  -- Test /apps/ with empty /apps/github (no owners)
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {
+      "/apps/ @octocat",
+      "/apps/github"
+    }
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  -- Files in /apps/github should have no owners (empty pattern overrides /apps/)
+  local githubResult = CO.matchFilesToCodeowner({"/apps/github/readme.md"})
+  lu.assertEquals(githubResult, {})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -241,4 +241,19 @@ function TestCO:testRootDocsDirectoryPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@doctocat"})
 end
 
+function TestCO:testRootScriptsDirectoryPattern() -- luacheck: ignore 212
+  -- Test /scripts/ pattern with multiple owners
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"/scripts/ @doctocat @octocat"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"/scripts/deploy.sh", "/scripts/test.py"})
+  lu.assertEquals(result, {"@doctocat", "@octocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -256,4 +256,19 @@ function TestCO:testRootScriptsDirectoryPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@doctocat", "@octocat"})
 end
 
+function TestCO:testDoubleStarLogsPattern() -- luacheck: ignore 212
+  -- Test **/logs pattern matches any logs directory at any depth
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"**/logs @octocat"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"build/logs/error.log", "app/server/logs/access.log", "logs/debug.log"})
+  lu.assertEquals(result, {"@octocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -136,4 +136,19 @@ function TestCO:testTxtPattern() -- luacheck: ignore 212
   lu.assertEquals(result, {"@octo-org/octocats"})
 end
 
+function TestCO:testBuildLogsDirectoryPattern() -- luacheck: ignore 212
+  -- Test /build/logs/ pattern matches files in specific directory
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"/build/logs/ @doctocat"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"/build/logs/app.log", "/build/logs/error.log"})
+  lu.assertEquals(result, {"@doctocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -1,7 +1,79 @@
+-- Add local lua path for testing
+package.path = "./lua/?.lua;./lua/?/init.lua;" .. package.path
+
 local lu = require("luaunit")
 
-local function TestCodeowners()
-  lu.assertEquals(1, 1)
+-- Create minimal vim global for testing
+vim = {
+  split = function(s, sep)
+    local result = {}
+    local pattern = "([^" .. sep .. "]*)"
+    for match in string.gmatch(s .. sep, pattern .. sep) do
+      table.insert(result, match)
+    end
+    return result
+  end,
+  fs = {
+    dirname = function() return "/test/.github" end,
+    find = function() return {"/test/.github"} end,
+    dir = function(path)
+      -- Mock directory iterator - return .github directory for root, CODEOWNERS for .github
+      if path:match("%.github$") then
+        local called = false
+        return function()
+          if not called then
+            called = true
+            return "CODEOWNERS", "file"
+          end
+          return nil
+        end
+      else
+        -- Root directory - return .github directory
+        local called = false
+        return function()
+          if not called then
+            called = true
+            return ".github", "directory"
+          end
+          return nil
+        end
+      end
+    end
+  },
+  loop = {
+    cwd = function() return "/test" end
+  },
+  api = {
+    nvim_buf_get_name = function() return "" end
+  },
+  fn = {
+    bufnr = function() return 0 end,
+    buflisted = function() return 0 end
+  }
+}
+
+local CO = require("gh-co.co")
+
+TestCO = {}
+
+function TestCO:setUp()
+  -- Mock the FS.openCodeownersFileAsLines to return empty iterator for each test
+  self.FS = require("gh-co.fs")
+  self.originalOpenCodeownersFileAsLines = self.FS.openCodeownersFileAsLines
+  self.FS.openCodeownersFileAsLines = function()
+    return function() return nil end
+  end
+end
+
+function TestCO:tearDown()
+  -- Restore original function
+  self.FS.openCodeownersFileAsLines = self.originalOpenCodeownersFileAsLines
+end
+
+function TestCO:testMatchFilesToCodeownerEmpty() -- luacheck: ignore 212
+  -- Test empty file paths returns empty list
+  local result = CO.matchFilesToCodeowner({})
+  lu.assertEquals(result, {})
 end
 
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/co.test.lua
+++ b/lua/gh-co/co.test.lua
@@ -211,4 +211,19 @@ function TestCO:testCombinedWithGlobalPattern() -- luacheck: ignore 212
   lu.assertEquals(result3, {"@global-owner"})
 end
 
+function TestCO:testAppsDirectoryPattern() -- luacheck: ignore 212
+  -- Test apps/ pattern matches files in apps directory
+  self.FS.openCodeownersFileAsLines = function()
+    local lines = {"apps/ @octocat"}
+    local i = 0
+    return function()
+      i = i + 1
+      return lines[i]
+    end
+  end
+  
+  local result = CO.matchFilesToCodeowner({"apps/web/index.js", "apps/mobile/main.kt"})
+  lu.assertEquals(result, {"@octocat"})
+end
+
 os.exit(lu.LuaUnit.run())

--- a/lua/gh-co/fs.lua
+++ b/lua/gh-co/fs.lua
@@ -60,7 +60,9 @@ FS.getCodeownersFilePath = function()
 
   local rootDirContents = vim.fs.dir(rootDirName)
 
-  assert(rootDirContents, "Not able to detect project root directory. Maybe you should run nvim from the root of the project.")
+  assert(rootDirContents, [[
+    Not able to detect project root directory. Maybe you should run nvim from the root of the project.
+  ]])
 
   local githubDirName = nil
   local docsDirName = nil

--- a/lua/gh-co/syntax.lua
+++ b/lua/gh-co/syntax.lua
@@ -5,8 +5,14 @@ local function setup_highlight_groups()
   vim.api.nvim_set_hl(0, "CodeownersComment", { link = "Comment" })
   vim.api.nvim_set_hl(0, "CodeownersPath", { link = "Identifier" })
   vim.api.nvim_set_hl(0, "CodeownersGlobalPath", { link = "Special" })
-  vim.api.nvim_set_hl(0, "CodeownersOwner", { link = "String" })
-  vim.api.nvim_set_hl(0, "CodeownersEmail", { link = "Constant" })
+
+  -- Try to use treesitter highlight groups for better theming
+  local has_treesitter = pcall(require, 'nvim-treesitter')
+  if has_treesitter and vim.fn.hlexists("@string.special") == 1 then
+    vim.api.nvim_set_hl(0, "CodeownersOwner", { link = "@string.special" })
+  else
+    vim.api.nvim_set_hl(0, "CodeownersOwner", { link = "String" })
+  end
 end
 
 local function highlight_line(bufnr, line_num, line_content)

--- a/lua/gh-co/syntax.lua
+++ b/lua/gh-co/syntax.lua
@@ -56,22 +56,17 @@ local function highlight_line(bufnr, line_num, line_content)
 
   for i = 2, #parts do
     local owner = parts[i]
-    local owner_start = remaining_line:find(vim.pesc(owner), 1, true)
+    local owner_start = remaining_line:find(owner, 1, true)
 
     if owner_start then
       local actual_start = offset + owner_start - 1
       local actual_end = actual_start + #owner
 
       -- Determine highlight group based on owner format
-      if owner:match("^@[%w_%-]+/[%w_%-]+$") or owner:match("^@[%w_%-]+$") then
+      if owner:find("@") then
         vim.api.nvim_buf_set_extmark(bufnr, ns_id, line_num, actual_start, {
           end_col = actual_end,
           hl_group = "CodeownersOwner"
-        })
-      elseif owner:match("^[%w%.%%_%+%-]+@[%w%.%-]+%.[%w]+$") then
-        vim.api.nvim_buf_set_extmark(bufnr, ns_id, line_num, actual_start, {
-          end_col = actual_end,
-          hl_group = "CodeownersEmail"
         })
       end
 

--- a/lua/setup.lua
+++ b/lua/setup.lua
@@ -1,0 +1,7 @@
+local version = _VERSION:match("%d+%.%d+")
+
+package.path = 'lua_modules/share/lua/' .. version ..
+    '/?.lua;lua_modules/share/lua/' .. version ..
+    '/?/init.lua;' .. package.path
+package.cpath = 'lua_modules/lib/lua/' .. version ..
+    '/?.so;' .. package.cpath

--- a/readme.MD
+++ b/readme.MD
@@ -57,3 +57,19 @@ Show codeowners for files in all buffers.
 ### `:GhCoGitWho <SHA>`
 
 Show codeowners for files affected by commit SHA.
+
+## Development
+
+Project is using luarocks to manage dependencies. After cloning the repo run:
+
+```bash
+luarocks install --deps-only gh-co.nvim-0.0.4-1.rockspec
+```
+
+### Lint
+
+Run `PATH="./lua_modules/bin:PATH" luacheck lua` to lint the codebase
+
+### Test
+
+TBD

--- a/readme.MD
+++ b/readme.MD
@@ -63,7 +63,7 @@ Show codeowners for files affected by commit SHA.
 Project is using luarocks to manage dependencies. After cloning the repo run:
 
 ```bash
-luarocks install --deps-only gh-co.nvim-0.0.4-1.rockspec
+luarocks install --deps-only gh-co.nvim-0.0.5-1.rockspec
 ```
 
 ### Lint

--- a/readme.MD
+++ b/readme.MD
@@ -72,4 +72,4 @@ Run `PATH="./lua_modules/bin:PATH" luacheck lua` to lint the codebase
 
 ### Test
 
-TBD
+Run `luarocks test`


### PR DESCRIPTION
This PR fixes issues with incorrect implementation of CODEOWNERS spec. The initial approach was very naive, basically just matching substrings, but there's more to it such as:

- `**` patterns
- specificity of folders
- `*.*` extension patterns
- excluding subfolders from ownership

I ended up generating tests according to that spec and integrated the codebase to use package management via `luarocks`. Tests are using `luaunit`.