### PR TITLE
Fix CODEOWNERS file search when `.github` or `docs` folders are not present

### DIFF
--- a/lua/gh-co/fs.lua
+++ b/lua/gh-co/fs.lua
@@ -79,6 +79,7 @@ FS.getCodeownersFilePath = function()
 
   local codeownerFilePath = nil
   -- picking the best matching CODEOWNERS file according to priority
+  -- luacheck: ignore 631
   -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
   if hasGithubDir and hasCodeownersFile(rootDirName .. '/.github') then
     codeownerFilePath = rootDirName .. '/.github/CODEOWNERS'

--- a/lua/gh-co/fs.lua
+++ b/lua/gh-co/fs.lua
@@ -2,16 +2,14 @@ local FS = {}
 
 FS.cachedCodeownersFilePath = nil
 
-local function hasGithubDirectory(name, kind)
-  return name == '.github' and kind == 'directory'
-end
-
-local function hasDocsDirectory(name, kind)
-  return name == 'docs' and kind == 'directory'
-end
-
-local function hasCodeownersFile(name, kind)
-  return name == 'CODEOWNERS' and kind == 'file'
+local function hasCodeownersFile(path)
+  local dirContents = vim.fs.dir(path)
+  for name, kind in dirContents do
+    if name == 'CODEOWNERS' and kind == 'file' then
+      return true
+    end
+  end
+  return false
 end
 
 local function getRootDirectoryName(currentPath)
@@ -64,54 +62,32 @@ FS.getCodeownersFilePath = function()
     Not able to detect project root directory. Maybe you should run nvim from the root of the project.
   ]])
 
-  local githubDirName = nil
-  local docsDirName = nil
+  local hasGithubDir = false
+  local hasDocsDir = false
+  local hasRootCodeowners = false
   for name, kind in rootDirContents do
-    if hasGithubDirectory(name, kind) then
-      githubDirName = name
-    end
-
-    if hasDocsDirectory(name, kind) then
-      docsDirName = name
-    end
-  end
-
-  local codeownerDirName = rootDirName .. "/" .. githubDirName or docsDirName
-  local codeownerDirContents = vim.fs.dir(codeownerDirName)
-
-  assert(
-    codeownerDirContents,
-    "Directory " .. codeownerDirName .. " does not seem to exist."
-  )
-
-  local codeownerFileNameWithinDefaultFolder = nil
-  for name, kind in codeownerDirContents do
-    if hasCodeownersFile(name, kind) then
-      codeownerFileNameWithinDefaultFolder = name
-      break
+    if kind == 'directory' then
+      if name == '.github' then
+        hasGithubDir = true
+      elseif name == 'docs' then
+        hasDocsDir = true
+      end
+    elseif kind == 'file' and name == 'CODEOWNERS' then
+      hasRootCodeowners = true
     end
   end
 
   local codeownerFilePath = nil
-
-  -- handles case when project is storing CODEOWNERS file in root directory
-  if codeownerFileNameWithinDefaultFolder == nil then
-    for name, kind in vim.fs.dir(rootDirName) do
-      if hasCodeownersFile(name, kind) then
-        codeownerFilePath = rootDirName .. "/" .. name
-        FS.cachedCodeownersFilePath = codeownerFilePath
-        break
-      end
-    end
-
-    return codeownerFilePath
-  else
-    codeownerFilePath = codeownerDirName .. "/" .. codeownerFileNameWithinDefaultFolder
-
-    FS.cachedCodeownersFilePath = codeownerFilePath
-
-    return codeownerFilePath
+  if hasGithubDir and hasCodeownersFile(rootDirName .. '/.github') then
+    codeownerFilePath = rootDirName .. '/.github/CODEOWNERS'
+  elseif hasDocsDir and hasCodeownersFile(rootDirName .. '/docs') then
+    codeownerFilePath = rootDirName .. '/docs/CODEOWNERS'
+  elseif hasRootCodeowners then
+    codeownerFilePath = rootDirName .. '/CODEOWNERS'
   end
+
+  FS.cachedCodeownersFilePath = codeownerFilePath
+  return codeownerFilePath
 end
 
 FS.openCodeownersFile = function()

--- a/lua/gh-co/fs.lua
+++ b/lua/gh-co/fs.lua
@@ -15,7 +15,7 @@ end
 local function getRootDirectoryName(currentPath)
   local dir = vim.fs.dirname(
     vim.fs.find(
-      { ".github", "docs" },
+      { ".github", "docs", "CODEOWNERS" },
       {
         path = currentPath,
         upward = true
@@ -78,12 +78,14 @@ FS.getCodeownersFilePath = function()
   end
 
   local codeownerFilePath = nil
+  -- picking the best matching CODEOWNERS file according to priority
+  -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
   if hasGithubDir and hasCodeownersFile(rootDirName .. '/.github') then
     codeownerFilePath = rootDirName .. '/.github/CODEOWNERS'
-  elseif hasDocsDir and hasCodeownersFile(rootDirName .. '/docs') then
-    codeownerFilePath = rootDirName .. '/docs/CODEOWNERS'
   elseif hasRootCodeowners then
     codeownerFilePath = rootDirName .. '/CODEOWNERS'
+  elseif hasDocsDir and hasCodeownersFile(rootDirName .. '/docs') then
+    codeownerFilePath = rootDirName .. '/docs/CODEOWNERS'
   end
 
   FS.cachedCodeownersFilePath = codeownerFilePath

--- a/lua/gh-co/fs.test.lua
+++ b/lua/gh-co/fs.test.lua
@@ -1,0 +1,316 @@
+-- Test suite for FS module CODEOWNERS file location logic
+--
+-- luacheck: ignore 631
+-- GitHub CODEOWNERS Standard (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location):
+-- Valid locations in priority order:
+--   1. .github/CODEOWNERS (highest priority)
+--   2. CODEOWNERS (root directory)
+--   3. docs/CODEOWNERS (lowest priority)
+--
+-- When multiple files exist, GitHub uses the first one found in priority order.
+
+package.path = "./lua/?.lua;./lua/?/init.lua;" .. package.path
+
+local lu = require("luaunit")
+
+-- Helper function to create mock vim.fs based on scenario
+local function createMockVimFs(scenario)
+  return {
+    dirname = function(path)
+      if path and #path > 0 then
+        return scenario.rootPath
+      end
+      return nil
+    end,
+
+    find = function(_names, _opts)
+      -- Return root path if any of the search targets exist
+      if scenario.hasGithubDir or scenario.hasDocsDir or scenario.rootHasCodeowners then
+        return {scenario.rootPath .. "/.github"}  -- any child path works
+      end
+      return {}
+    end,
+
+    dir = function(path)
+      if path == scenario.rootPath then
+        -- Root directory contents
+        local items = {}
+        if scenario.hasGithubDir then
+          table.insert(items, {".github", "directory"})
+        end
+        if scenario.hasDocsDir then
+          table.insert(items, {"docs", "directory"})
+        end
+        if scenario.rootHasCodeowners then
+          table.insert(items, {"CODEOWNERS", "file"})
+        end
+
+        local i = 0
+        return function()
+          i = i + 1
+          if items[i] then
+            return items[i][1], items[i][2]
+          end
+          return nil
+        end
+      elseif path == scenario.rootPath .. "/.github" then
+        -- .github directory contents
+        if scenario.githubHasCodeowners then
+          local called = false
+          return function()
+            if not called then
+              called = true
+              return "CODEOWNERS", "file"
+            end
+            return nil
+          end
+        end
+        return function() return nil end
+      elseif path == scenario.rootPath .. "/docs" then
+        -- docs directory contents
+        if scenario.docsHasCodeowners then
+          local called = false
+          return function()
+            if not called then
+              called = true
+              return "CODEOWNERS", "file"
+            end
+            return nil
+          end
+        end
+        return function() return nil end
+      end
+
+      return function() return nil end
+    end
+  }
+end
+
+-- Test class
+TestFS = {}
+
+function TestFS:setUp()
+  self.FS = require("gh-co.fs")
+  -- Clear cached path
+  self.FS.cachedCodeownersFilePath = nil
+
+  -- Save original vim global
+  self.originalVim = _G.vim
+
+  -- Mock minimal vim APIs needed for FS module
+  _G.vim = {
+    api = {
+      nvim_buf_get_name = function() return "/test/file.txt" end
+    },
+    loop = {
+      cwd = function() return "/test" end
+    },
+    fs = {}  -- Will be replaced per test
+  }
+end
+
+function TestFS:tearDown()
+  -- Restore original vim global
+  _G.vim = self.originalVim
+
+  -- Clear module cache to reload fresh for next test
+  package.loaded["gh-co.fs"] = nil
+end
+
+-- =============================================================================
+-- Priority Tests: Verify GitHub's priority order when multiple files exist
+-- =============================================================================
+
+-- Priority #1 > #2: When both .github/CODEOWNERS and root/CODEOWNERS exist,
+-- .github/CODEOWNERS should be selected (highest priority)
+function TestFS:testPriorityGithubOverRoot() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = true,
+    hasDocsDir = false,
+    githubHasCodeowners = true,
+    docsHasCodeowners = false,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/.github/CODEOWNERS")
+end
+
+-- Priority #2 > #3: When both root/CODEOWNERS and docs/CODEOWNERS exist,
+-- root/CODEOWNERS should be selected (priority 2 over 3)
+function TestFS:testPriorityRootOverDocs() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = false,
+    hasDocsDir = true,
+    githubHasCodeowners = false,
+    docsHasCodeowners = true,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/CODEOWNERS")
+end
+
+-- Priority #1 > #2 > #3: When all three standard locations have CODEOWNERS,
+-- .github/CODEOWNERS should be selected (highest priority)
+function TestFS:testPriorityAllThreeLocations() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = true,
+    hasDocsDir = true,
+    githubHasCodeowners = true,
+    docsHasCodeowners = true,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/.github/CODEOWNERS")
+end
+
+-- =============================================================================
+-- Standard Location Tests: Single CODEOWNERS file in valid location
+-- =============================================================================
+
+-- Standard location #2: CODEOWNERS in repository root (most common simple setup)
+function TestFS:testRootCodeownersWithoutGithubDocsDir() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = false,
+    hasDocsDir = false,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/CODEOWNERS")
+end
+
+-- =============================================================================
+-- Fallback Scenarios: Directories exist but lack CODEOWNERS files
+-- =============================================================================
+
+-- Fallback when .github directory exists but has no CODEOWNERS file,
+-- should fall back to root/CODEOWNERS (priority #2)
+function TestFS:testGithubDirWithoutCodeownersFile() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = true,
+    hasDocsDir = false,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/CODEOWNERS")
+end
+
+-- Fallback when docs directory exists but has no CODEOWNERS file,
+-- should fall back to root/CODEOWNERS (priority #2)
+function TestFS:testDocsDirWithoutCodeownersFile() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = false,
+    hasDocsDir = true,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/CODEOWNERS")
+end
+
+-- Fallback when both .github and docs directories exist but neither has CODEOWNERS,
+-- should fall back to root/CODEOWNERS (priority #2)
+function TestFS:testBothDirsWithoutCodeownersFiles() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = true,
+    hasDocsDir = true,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = true
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, "/test/CODEOWNERS")
+end
+
+-- =============================================================================
+-- Edge Cases: Scenarios where no CODEOWNERS file can be found
+-- =============================================================================
+
+-- No CODEOWNERS file exists in any of the three standard locations
+function TestFS:testNoCodeownersAnywhere() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = true,
+    hasDocsDir = true,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = false
+  }
+
+  _G.vim.fs = createMockVimFs(scenario)
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, nil)
+end
+
+-- Repository root directory cannot be detected (no .github, docs, or CODEOWNERS markers found)
+function TestFS:testNoRootDetection() -- luacheck: ignore 212
+  local scenario = {
+    rootPath = "/test",
+    hasGithubDir = false,
+    hasDocsDir = false,
+    githubHasCodeowners = false,
+    docsHasCodeowners = false,
+    rootHasCodeowners = false
+  }
+
+  -- Override find to return empty array (no root found)
+  _G.vim.fs = createMockVimFs(scenario)
+  _G.vim.fs.find = function() return {} end
+
+  package.loaded["gh-co.fs"] = nil
+  local FS = require("gh-co.fs")
+
+  local result = FS.getCodeownersFilePath()
+  lu.assertEquals(result, nil)
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
Hey @comatory , thank you for the awesome plugin, really helpful stuff.

That said, I encountered an issue when a repo has `docs` folder without any CODEOWNERS in it. On init it throws:

```
plugin/gh-co/gh-co.vim, line 7: Vim(lua):E5108: Error executing lua ...giosa/.local/share/nvim/lazy/gh-co.nvim/lua/gh-co/fs.lua:79: attempt to concatenate local 'githubDirName' (a nil value)
```

<details>
<summary>stack trace</summary>

```
Failed to source `/home/religiosa/.local/share/nvim/lazy/gh-co.nvim/plugin/gh-co/gh-co.vim`

vim/_editor.lua:0: /home/religiosa/.config/nvim/init.lua..nvim_exec2() called at /home/religiosa/.config/nvim/init.lua:0[1]../home/religiosa/.local/share/nvim/lazy/gh-co.nvim/plugin/gh-co/gh-co.vim, line 7: Vim(lua):E5108: Error executing lua ...giosa/.local/share/nvim/lazy/gh-co.nvim/lua/gh-co/fs.lua:79: attempt to concatenate local 'githubDirName' (a nil value)
stack traceback:
	...giosa/.local/share/nvim/lazy/gh-co.nvim/lua/gh-co/fs.lua:79: in function 'getCodeownersFilePath'
	...osa/.local/share/nvim/lazy/gh-co.nvim/lua/gh-co/init.lua:115: in function 'init'
	[string ":lua"]:1: in main chunk
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:510: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:509>
	[C]: in function 'xpcall'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135: in function 'try'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:509: in function 'source'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:457: in function 'source_runtime'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:425: in function 'packadd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:359: in function '_load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:197: in function 'load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:127: in function 'startup'
	...giosa/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112: in function 'setup'
	/home/religiosa/.config/nvim/lua/config/lazy.lua:17: in main chunk
	[C]: in function 'require'
	/home/religiosa/.config/nvim/init.lua:2: in main chunk

# stacktrace:
  - vim/_editor.lua:0 _in_ **cmd**
  - ~/.config/nvim/lua/config/lazy.lua:17
  - ~/.config/nvim/init.lua:2
```

</details>

The immediate issue seems to be caused by missed parentheses in the fallback condition in fs.lua:79:

```diff
- local codeownerDirName = rootDirName .. "/" .. githubDirName or docsDirName
+ local codeownerDirName = rootDirName .. "/" .. (githubDirName or docsDirName)
```

Though just adding parenthesis will prevent the error on init, it sill leaves the core functionality broken, if you have CODEOWNERS at root. Also, if we have `.github` folder without the CODEOWNERS file -- and the file being in either `docs` or at the root level it won't be picked by the plugin as we don't check for the presence of the file in the `.github` folder  before choosing it.

This PR modifies the behavior of the `FS.getCodeownersFilePath` so it checks for the CODEOWNERS file presence in the `.github` foleder, and then root-level, and then `docs` folders (the order as specified in the [Github Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)).

It also adds "CODEOWNERS" to the `vim.fs.find` arguments in `getRootDirectoryName` in FS, so we don't miss the cached codeowners file when neither `.github` nor `docs` folders are present.

I verified the changes on the local test setup with the following scenarios:

- just the `docs` folder present, no CODEOWNERS -- no error thrown on init
- picking CODEOWENRS from the `docs` folder when `.github` folder is also present in the repo
- picking root-level CODEOWNERS with both `.github` and `docs` folders present, either one of them, or none of them
- picking CODEOWNERS file from `docs` when `.github` is both present and not
- picking CODEOWNERS filr from `.github` when `docs` is both present and not